### PR TITLE
Update eval-settings.cc

### DIFF
--- a/src/libexpr/eval-settings.cc
+++ b/src/libexpr/eval-settings.cc
@@ -48,7 +48,10 @@ EvalSettings::EvalSettings(bool & readOnlyMode, EvalSettings::LookupPathHooks lo
     : readOnlyMode{readOnlyMode}
     , lookupPathHooks{lookupPathHooks}
 {
-    auto var = getEnv("NIX_ABORT_ON_WARN");
+    auto var = getEnv("NIX_PATH");
+    if (var) nixPath = parseNixPath(*var);
+
+    var = getEnv("NIX_ABORT_ON_WARN");
     if (var && (var == "1" || var == "yes" || var == "true"))
         builtinsAbortOnWarn = true;
 }


### PR DESCRIPTION
Motivation
This change ensures that the build process respects the NIX_ABORT_ON_WARN environment variable, allowing users to enforce stricter handling of build warnings by aborting the build if this variable is set to 1, yes, or true.

Context
The update adds checks for the NIX_ABORT_ON_WARN environment variable and sets the builtinsAbortOnWarn flag accordingly, improving build robustness and configurability.